### PR TITLE
fix: edit link to Constant evaluation page of Rust Reference site

### DIFF
--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -188,4 +188,4 @@ const THREE_HOURS_IN_SECONDS: u32 = 60 * 60 * 3;
 ch02-00-guessing-game-tutorial.html#%EB%B9%84%EB%B0%80%EB%B2%88%ED%98%B8%EC%99%80-%EC%B6%94%EB%A6%AC%EA%B0%92%EC%9D%84-%EB%B9%84%EA%B5%90%ED%95%98%EA%B8%B0
 [data-types]: ch03-02-data-types.html#data-types
 [storing-values-with-variables]: ch02-00-guessing-game-tutorial.html#storing-values-with-variables
-[const-eval]: ../reference/const_eval.html
+[const-eval]: https://doc.rust-lang.org/stable/reference/const_eval.html


### PR DESCRIPTION
[상숫값 평가에 대한 러스트 참고 자료 절]의 링크가 상대 경로로 되어 있으나, 
현재 한국어 번역본의 경우 Rust Reference의 경로가 존재하지 않아 클릭 시 404 Page가 보여집니다. 원본 링크일지라도 정보가 있는 링크로 이동되어야 한다고 생각해서 원본 링크인
(https://doc.rust-lang.org/stable/reference/const_eval.html) 으로 이동되도록 수정하였습니다.