### PR TITLE
Fix typo in ch02-00

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -144,7 +144,7 @@ let apples = 5;
 
 ```rust,ignore
 let apples = 5; // immutable
-let mut bananas= 5; // mutable
+let mut bananas = 5; // mutable
 ```
 
 > Note: `//` 문법은 현재 위치부터 라인의 끝까지 주석임을 나타냅니다.


### PR DESCRIPTION
긴급하진 않고 되게 사소한 오타 수정입니다.

<img width="319" alt="image" src="https://github.com/user-attachments/assets/aea6b8fc-dee4-4b2f-9ab4-1bf578cb2c18" />

bananas와 = 사이에 공백이 없어서 추가했습니다.
